### PR TITLE
Supress package-lock.json diff on installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ repo = 'notomo/gesture.nvim'
 build = 'npm run setup'
 ```
 
+NOTE: If the npm version < 5.7, use `npm install & npm run build` instead of `npm run setup`.
+`npm run setup` requires `npm ci`.
+
 ## Usage
 
 ```vim

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ install:
     - npm install --global npm@latest
     - set PATH=%APPDATA%\npm;%PATH%
     - npm install -g neovim
-    - npm install
+    - npm ci
 
     - ps: |
         $zip = $Env:APPVEYOR_BUILD_FOLDER + '\nvim.zip'

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "test": "jest --coverage",
         "build": "tsc -p tsconfig.json",
         "watch": "tsc -p tsconfig.json --watch true",
-        "setup": "npm install && npm run build"
+        "setup": "npm ci && npm run build"
     },
     "jest": {
         "moduleFileExtensions": [


### PR DESCRIPTION
`npm run setup` requires `npm ci`